### PR TITLE
JVNファイルダウンロードの改善

### DIFF
--- a/Dashboard/WebContent/resources/js/common/constants.js
+++ b/Dashboard/WebContent/resources/js/common/constants.js
@@ -45,6 +45,8 @@ ENS.URL.JVN_LOG_NOTIFY_POSTFIX_ID = "/JvnLog_Notify";
 ENS.URL.PROFILER_POSTFIX_ID = "/profiler";
 ENS.URL.CONTROLLER_POSTFIX_ID = "/property";
 
+ENS.URL.JVNFILEDOWNLOAD_SEARCH = "/jvnFileDownload/search";
+
 ENS.common = {};
 ENS.common.dualslider = {};
 ENS.common.dualslider.scaleUnitStrings = 'hours';// for many hours

--- a/Dashboard/WebContent/resources/js/map/view/jvnFileDownloadView.js
+++ b/Dashboard/WebContent/resources/js/map/view/jvnFileDownloadView.js
@@ -1,19 +1,34 @@
 ENS.jvnFileDwonloadView = wgp.AbstractView.extend({
-	initialize : function(argument) {
+	initialize : function(argument, treeSettings) {
+		this.treeSettings = treeSettings;
+		this.tableMargin = 20;
+		this.tableWidth = parseInt($("#" + this.id).width()
+				- this.tableMargin * 4);
 		this.render();
 	},
 	render : function() {
-		var $downloadDiv = $("<div id='jvnFileDownload'>Javelin Log File Download</div>");
+		var instance = this;
+		var $br = $("<br/>");
+
+		var $downloadDiv = $("<div id='jvnFileDownload'>Javelin Log File Download</div>").append($br.clone(true));
+		$downloadDiv.css("font-size", "0.8em");
+
+		var $divStartDate = $("<div></div>");
+		$divStartDate.css("float", "left");
+		
 		var $startDatePicker = $("<input/>");
 		$startDatePicker.attr("name", "start");
 		$startDatePicker.attr("type", "text");
 		$startDatePicker.attr("title", "From date");
+
 		
 		$startDatePicker.datetimepicker({
 			dateFormat : "yy-mm-dd",
 			timeFormat : "HH:mm"
 		});
 
+		var $divEndDate = $("<div></div>");
+		
 		var $endDatePicker = $("<input/>");
 		$endDatePicker.attr("name", "end");
 		$endDatePicker.attr("type", "text");
@@ -24,33 +39,106 @@ ENS.jvnFileDwonloadView = wgp.AbstractView.extend({
 			timeFormat : "HH:mm"
 		});
 
-		var $downloadButton = $("<button/>");
-		$downloadButton.attr("name", "download");
-		$downloadButton.attr("type", "button");
-		$downloadButton.html("get Javelin Logs");
-		$downloadButton.css("margin-left", "100px");
+		$divStartDate.append("<label>From：</label>");
+		$divStartDate.append($startDatePicker);
+		$divStartDate.append($br.clone(true));
+		$downloadDiv.append($divStartDate);
+		
+		$divEndDate.append("<label>　To：</label>");
+		$divEndDate.append($endDatePicker);
+
+		$downloadDiv.append($divEndDate);
+		$downloadDiv.append($br.clone(true));
+		
+		var $searchButton = $("<button/>");
+		$searchButton.attr("id", "jvnFileDownloadSearch");
+		$searchButton.attr("name", "search");
+		$searchButton.attr("type", "button");
+		$searchButton.css("margin-bottom", "10px");
+		$searchButton.html("Search");
+		$downloadDiv.append($searchButton);
 
 		// ファイルダウンロード用のフォーム
 		var $downloadForm = $("<form id='jvnFileDownloadForm'></form>");
 		$downloadForm.attr("action", '/ENdoSnipe/jvnFileDownload/download');
 		$downloadForm.attr("target", "resultForm")
 		$downloadForm.attr("method", "POST");
-		
-		var $br = $("<br/>");
-		$downloadForm.append("<label>From</label>").append($br.clone(true));
-		$downloadForm.append($startDatePicker).append($br.clone(true));
-		$downloadForm.append("<label>To</label>").append($br.clone(true));
-		$downloadForm.append($endDatePicker).append($br.clone(true)).append($br.clone(true));
-		$downloadForm.append($downloadButton);
 
+		// ファイルダウンロード対象として指定するログID格納用（複数）
+		var $logIds = $("<input/>");
+		$logIds.attr("id", "logIds");
+		$logIds.attr("name", "logIds");
+		$logIds.attr("type", "hidden");
+		$downloadForm.append($logIds);
+
+		
+		var $downloadTable = $("<table id='jvnFileDownloadTable'></table>");
+		var $downloadPager = $("<div id='jvnFileDownloadPager'></div>");
+		var $downloadButton = $("<button/>");
+		$downloadButton.attr("id", "jvnFileDownloadExecute");
+		$downloadButton.attr("name", "download");
+		$downloadButton.attr("type", "button");
+		$downloadButton.html("Download");
+		$downloadButton.css({
+			"margin-right" : $("#contents_area_content").width()- (this.tableWidth + 5),
+			"width" : 150,
+			"height" : 30,
+			"float" : "right"
+		});
+		
 		$downloadDiv.append($downloadForm);
+		$downloadDiv.append($downloadTable).append($br.clone(true));
+		$downloadDiv.append($downloadPager);
+		$downloadDiv.append($downloadButton);
 		$("#" + this.id).append($downloadDiv);
 
+		// ダウンロード用のIフレーム
 		var $iframe= $("<iframe/>");
 		$iframe.hide();
 		$("#" + this.id).append($iframe);
 
+		// JVNファイル絞り込み結果テーブル描画
+		this.renderTable();
+
+		// 絞り込みボタンイベント設定
+		$searchButton.on("click", function(event) {
+			var start = null;
+			var end = null;
+
+			if (!$startDatePicker.prop("disabled")) {
+				start = $startDatePicker.val();
+			}
+
+			if (!$endDatePicker.prop("disabled")) {
+				end = $endDatePicker.val();
+			} 
+			
+			var settings = {
+				data : {
+					agentName : instance.treeSettings.treeId,
+					start : start,
+					end : end
+				},
+				url : wgp.common.getContextPath() + ENS.URL.JVNFILEDOWNLOAD_SEARCH,
+				successCallObject : instance,
+				successCallFunction : "reloadTable"
+			}
+
+			var ajaxHandler = new wgp.AjaxHandler();
+			ajaxHandler.requestServerAsync(settings);
+		});
+
+		// ダウンロードボタンイベント設定
 		$downloadButton.on("click", function(event){
+
+			var logIdArray = [];
+			var selarrrow = $("#jvnFileDownloadTable").getGridParam("selarrrow");
+			_.each(selarrrow, function(rowId, index) {
+				var rowData = $("#jvnFileDownloadTable").getRowData(rowId);
+				logIdArray.push(rowData.logId);
+			});
+			$logIds.val(JSON.stringify(logIdArray));
+
 			var document = $iframe[0].contentDocument;
 			var $iframeBody = $("body", document);
 
@@ -59,6 +147,91 @@ ENS.jvnFileDwonloadView = wgp.AbstractView.extend({
 			iframeForm.submit();
 		});
 
+	},
+	renderTable : function() {
+		var instance = this;
+
+		$("#jvnFileDownloadTable").jqGrid(
+				{
+					datatype : "local",
+					data : "",
+					colModel : [
+			            {
+			            	name: "logId",
+			            	hidden: true
+			            },
+					    {
+					    	name: "logFileName",
+					    	hidden: true
+					    },
+			            {
+			            	name: "startTime",
+							width: parseInt(instance.tableWidth * 0.15),
+			            },
+			            {
+			            	name: "endTime",
+			            	width: parseInt(instance.tableWidth * 0.15)
+			            },
+			            {
+			            	name: "calleeClass",
+			            	width: parseInt(instance.tableWidth * 0.15)
+			            },
+			            {
+			            	name: "calleeName",
+			            	width: parseInt(instance.tableWidth * 0.15)
+			            },
+			            {
+			            	name: "elapsedTime",
+			            	width: parseInt(instance.tableWidth * 0.15)
+			            },
+			            {
+			            	name: "threadName",
+			            	width: parseInt(instance.tableWidth * 0.19)
+			            }
+		            ],
+					colNames : ["log id","log file name", "start time", "end time", "callee class", "callee name", "elapsed_time", "thread name"],
+					caption : "Download of " + instance.treeSettings.id,
+					pager : "jvnFileDownloadPager",
+					rowNum : 10000,
+					pgbuttons : true,
+					pginput : true,
+					height : "auto",
+					width : instance.tableWidth,
+					viewrecords : true,
+					rownumbers : false,
+					shrinkToFit : false,
+					sortname : "startTime",
+					sortorder : "desc",
+					multiselect : true,
+					scrollerbar : true,
+					cmTemplate : {
+						title : false
+					},
+					loadComplete : function() {
+						instance.reflectSelectState();
+					},
+					onSelectRow : function(id) {
+						instance.reflectSelectState();
+					}
+				});
+
+		$("#jvnFileDownloadTable").filterToolbar({
+			defaultSearch : 'cn'
+		});
+	},
+	reloadTable : function(data) {
+		$("#jvnFileDownloadTable").clearGridData().setGridParam({
+			data : data
+		}).trigger("reloadGrid");
+	},
+	reflectSelectState : function() {
+		var selarrrow = $("#jvnFileDownloadTable").getGridParam("selarrrow");
+		if(selarrrow && selarrrow.length > 0){
+			$("#jvnFileDownloadExecute").prop("disabled", false);
+		}
+		else {
+			$("#jvnFileDownloadExecute").prop("disabled", true);
+		}
 	},
 	onAdd : function(element) {
 		// Do nothing

--- a/Dashboard/src/main/java/jp/co/acroquest/endosnipe/web/explorer/controller/JvnFileDownloadController.java
+++ b/Dashboard/src/main/java/jp/co/acroquest/endosnipe/web/explorer/controller/JvnFileDownloadController.java
@@ -14,17 +14,25 @@ package jp.co.acroquest.endosnipe.web.explorer.controller;
 
 import java.io.OutputStream;
 import java.sql.Timestamp;
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 import javax.servlet.http.HttpServletResponse;
 
+import jp.co.acroquest.endosnipe.web.explorer.dto.JvnFileSearchResultDto;
 import jp.co.acroquest.endosnipe.web.explorer.service.JvnFileDownloadService;
+import net.arnx.jsonic.JSON;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * JVNファイルダウンロード機能のコントローラクラス
@@ -52,21 +60,58 @@ public class JvnFileDownloadController
 
     }
 
-    @RequestMapping(value = "/download", method = RequestMethod.POST)
-    public void download(@RequestParam(value = "start") final String start,
-            @RequestParam(value = "end") final String end, final HttpServletResponse res)
+    /**
+     * JVNログファイルを検索する。
+     * @param start 開始時刻
+     * @param end 終了時刻
+     * @param agentName エージェント名
+     * @param res レスポンス
+     */
+    @ResponseBody
+    @RequestMapping(value = "/search", method = RequestMethod.POST)
+    public List<JvnFileSearchResultDto> search(
+            @RequestParam(value = "agentName") final String agentName,
+            @RequestParam(value = "start", required = false) final String start,
+            @RequestParam(value = "end", required = false) final String end,
+            final HttpServletResponse res)
         throws Exception
     {
-        String fileName = "jvn_" + start + "_" + end + ".zip";
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+
+        Timestamp startTime = null;
+        Timestamp endTime = null;
+
+        if (!StringUtils.isEmpty(start))
+        {
+            startTime = new Timestamp(dateFormat.parse(start).getTime());
+        }
+
+        if (!StringUtils.isEmpty(end))
+        {
+            endTime = new Timestamp(dateFormat.parse(end).getTime());
+        }
+
+        return this.jvnFileDownloadService_.getJavelinLog(startTime, endTime, agentName);
+    }
+
+    @RequestMapping(value = "/download", method = RequestMethod.POST)
+    public void download(@RequestParam(value = "logIds") final String logIds,
+            final HttpServletResponse res)
+        throws Exception
+    {
+        List<String> logIdStrList = JSON.decode(logIds);
+        List<Long> logIdList = new ArrayList<Long>();
+        for (String logIdStr : logIdStrList)
+        {
+            logIdList.add(Long.valueOf(logIdStr));
+        }
+        DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+        String fileName = "jvn_" + dateFormat.format(new Date()) + ".zip";
         res.setContentType("application/octet-stream;charset=UTF8");
         res.setHeader("Content-Disposition", "attachment; filename=" + fileName);
         res.setHeader("Content-Transfer-Encoding", "binary");
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
-        Timestamp startTime = new Timestamp(dateFormat.parse(start).getTime());
-        Timestamp endTime = new Timestamp(dateFormat.parse(end).getTime());
-
         OutputStream os = res.getOutputStream();
-        this.jvnFileDownloadService_.writeFile(os, startTime, endTime);
+        this.jvnFileDownloadService_.writeFile(os, logIdList);
     }
 }

--- a/Dashboard/src/main/java/jp/co/acroquest/endosnipe/web/explorer/dto/JvnFileSearchResultDto.java
+++ b/Dashboard/src/main/java/jp/co/acroquest/endosnipe/web/explorer/dto/JvnFileSearchResultDto.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2004-2015 Acroquest Technology Co., Ltd. All Rights Reserved.
+ * Please read the associated COPYRIGHTS file for more details.
+ *
+ * THE  SOFTWARE IS  PROVIDED BY  Acroquest Technology Co., Ltd., WITHOUT  WARRANTY  OF
+ * ANY KIND,  EXPRESS  OR IMPLIED,  INCLUDING BUT  NOT LIMITED  TO THE
+ * WARRANTIES OF  MERCHANTABILITY,  FITNESS FOR A  PARTICULAR  PURPOSE
+ * AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * CLAIM, DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING
+ * OR DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+ */
+package jp.co.acroquest.endosnipe.web.explorer.dto;
+
+/**
+ * JVNファイルの検索結果DTO
+ * @author kawasaki
+ *
+ */
+public class JvnFileSearchResultDto
+{
+    /**
+     * ログID
+     */
+    private Long logId_;
+
+    /**
+     * ログファイル名
+     */
+    private String logFileName_;
+
+    /**
+     * 開始時刻
+     */
+    private String startTime_;
+
+    /**
+     * 終了時刻
+     */
+    private String endTime_;
+
+    /**
+     * 呼び出し先クラス
+     */
+    private String calleeClass_;
+
+    /**
+     * 呼び出し先メソッド
+     */
+    private String calleeName_;
+
+    /**
+     * 処理時間
+     */
+    private long elapsedTime_;
+
+    /**
+     * スレッド名
+     */
+    private String threadName_;
+
+    public Long getLogId()
+    {
+        return logId_;
+    }
+
+    public void setLogId(final Long logId)
+    {
+        logId_ = logId;
+    }
+
+    public String getLogFileName()
+    {
+        return logFileName_;
+    }
+
+    public void setLogFileName(final String logFileName)
+    {
+        logFileName_ = logFileName;
+    }
+
+    public String getStartTime()
+    {
+        return startTime_;
+    }
+
+    public void setStartTime(final String startTime)
+    {
+        startTime_ = startTime;
+    }
+
+    public String getEndTime()
+    {
+        return endTime_;
+    }
+
+    public void setEndTime(final String endTime)
+    {
+        endTime_ = endTime;
+    }
+
+    public String getCalleeClass()
+    {
+        return calleeClass_;
+    }
+
+    public void setCalleeClass(final String calleeClass)
+    {
+        calleeClass_ = calleeClass;
+    }
+
+    public String getCalleeName()
+    {
+        return calleeName_;
+    }
+
+    public void setCalleeName(final String calleeName)
+    {
+        calleeName_ = calleeName;
+    }
+
+    public long getElapsedTime()
+    {
+        return elapsedTime_;
+    }
+
+    public void setElapsedTime(final long elapsedTime)
+    {
+        elapsedTime_ = elapsedTime;
+    }
+
+    public String getThreadName()
+    {
+        return threadName_;
+    }
+
+    public void setThreadName(final String threadName)
+    {
+        threadName_ = threadName;
+    }
+}


### PR DESCRIPTION
改善内容
①JVNファイルは左側ツリーで選択したエージェント配下のみ検索されること。
②JVNファイルの検索結果を表示するグリッドを作成すること。
③②のグリッドから指定した行に該当するJVNファイルがダウンロードできること。
④類似ログについて絞り込めること。

上記のうち、①～③について対応した。
