### PR TITLE
issues #619 #621 [Dashboard] テキスト編集時のフォント・整列ドロップダウンリストのサイズを統一した。

### DIFF
--- a/Dashboard/WebContent/resources/css/map/dashboard.css
+++ b/Dashboard/WebContent/resources/css/map/dashboard.css
@@ -50,18 +50,17 @@
 
 .dashboardPropertyFontItem {
 	clear:both;
-	height : 40px;
+	height : 35px;
 }
 
 .dashboardPropertyFontItem div{
 	width: 200px;
-	height: 30px;
+	height: 25px;
 	float: left;
 	margin-left: 10px;
 }
 
 .dashboardPropertyFontItem select{
 	width: 200px;
-	height : 30px;
-	font-size : 20px;
+	height : 25px;
 }

--- a/Dashboard/WebContent/resources/js/map/dialog/dashboardElementPropertyView.js
+++ b/Dashboard/WebContent/resources/js/map/dialog/dashboardElementPropertyView.js
@@ -679,7 +679,7 @@ ENS.DashboardElementPropertyTextboxTab = ENS.DashboardElementPropertyTextTab.ext
 				textAnchorAttribute.type,
 				this.property.textAnchor,
 				textAnchorAttribute.selection);
-		var textAnchorRow = $("<div class='dashboardPropertyItem'></div>");
+		var textAnchorRow = $("<div class='dashboardPropertyFontItem'></div>");
 		textAnchorRow.append(textAnchorSpan).append(textAnchorSelect);
 		parentDiv.append(textAnchorRow);
 		return parentDiv;


### PR DESCRIPTION
#619 #621 の対応で、
Dashboardのテキスト編集時のフォント・整列ドロップダウンリストの幅とフォントサイズを統一し、高さを文字が見切れないように修正しましたのでマージお願いします。
![619_621_](https://cloud.githubusercontent.com/assets/3169718/9286819/acdc475a-4337-11e5-9563-588efe48c0a5.PNG)
