### PR TITLE
issues #692 Javelin-DataCollector間の電文サイズの削減を行った。

### DIFF
--- a/ENdoSnipeCommunicator/src/main/java/jp/co/acroquest/endosnipe/communicator/accessor/SqlPlanNotifyAccessor.java
+++ b/ENdoSnipeCommunicator/src/main/java/jp/co/acroquest/endosnipe/communicator/accessor/SqlPlanNotifyAccessor.java
@@ -90,11 +90,11 @@ public class SqlPlanNotifyAccessor implements TelegramConstants
                 String sqlStatement = (String)objItemValueArr[0];
                 sqlStatements.add(sqlStatement);
 
-                // 項目名が圧縮されている場合も考慮して、解凍後の計測項目名を取得する
-                String mearsurmentItemName =
-                    TelegramUtil.getMeasurementItemName(itemNameIdMapList, responseBody, agentName);
+                // 項目名が圧縮されている場合も考慮して、解凍後の項目名を取得する
+                String itemName =
+                    TelegramUtil.getMeasurementItemName(itemNameIdMapList, responseBody);
 
-                measurmentItemNames.add(mearsurmentItemName);
+                measurmentItemNames.add(agentName + itemName);
             }
             else if (OBJECTNAME_SQL_EXECUTION_PLAN.equals(objectName) == true)
             {

--- a/ENdoSnipeCommunicator/src/main/java/jp/co/acroquest/endosnipe/communicator/entity/TelegramConstants.java
+++ b/ENdoSnipeCommunicator/src/main/java/jp/co/acroquest/endosnipe/communicator/entity/TelegramConstants.java
@@ -840,4 +840,8 @@ public interface TelegramConstants
 
     /** 項目名(ストール検出回数) */
     String ITEMNAME_JAVAPROCESS_METHOD_STALL_COUNT = "javaprocess.method.stall.count";
+    
+    // -----------------------------------------------------
+    // 電文サイズの短縮対象にする項目名の長さ
+    int COMPRESSION_ITEM_NAME_LENGTH = 50;
 }


### PR DESCRIPTION
同じ電文内にある項目名の共通部分の文字数が50以上の時に、その共通部分をキー文字列に置き換えることで電文サイズを削減するようにした。